### PR TITLE
Revert "Pin pylint to 2.14.5 because 2.15.0 breaks pylint-django"

### DIFF
--- a/devel.txt
+++ b/devel.txt
@@ -4,6 +4,5 @@ black
 coverage
 flake8
 parameterized
-pylint==2.14.5
 pylint-django
 kiwitcms-django-plugin

--- a/trackers_integration/issuetracker/openproject.py
+++ b/trackers_integration/issuetracker/openproject.py
@@ -43,7 +43,7 @@ class API:
 
     @staticmethod
     def _request(method, url, **kwargs):
-        return requests.request(method, url, **kwargs).json()
+        return requests.request(method, url, timeout=30, **kwargs).json()
 
     def get_projects(self, name=None):
         url = f"{self.base_url}/projects"


### PR DESCRIPTION
This reverts commit 417f7ad20f8c1b8ed4b13603c69d4e84abf947a5.

Fixes #8.