### PR TITLE
Mantis bug tracker integration.Fixes #879

### DIFF
--- a/tcms_settings_dir/trackers_integration.py
+++ b/tcms_settings_dir/trackers_integration.py
@@ -10,3 +10,11 @@ if (
     EXTERNAL_BUG_TRACKERS.append(  # noqa: F821
         "trackers_integration.issuetracker.OpenProject"
     )
+
+if (
+    "trackers_integration.issuetracker.Mantis"
+    not in EXTERNAL_BUG_TRACKERS  # noqa: F821
+):
+    EXTERNAL_BUG_TRACKERS.append(  # noqa: F821
+        "trackers.integration.issuetracker.Mantis"
+    )

--- a/trackers_integration/issuetracker/__init__.py
+++ b/trackers_integration/issuetracker/__init__.py
@@ -10,3 +10,4 @@
     .. versionadded:: 11.6-Enterprise
 """
 from .openproject import OpenProject  # noqa
+from .mantis import Mantis  # noqa

--- a/trackers_integration/issuetracker/mantis.py
+++ b/trackers_integration/issuetracker/mantis.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+import requests
+
+from tcms.core.contrib.linkreference.models import LinkReference
+from tcms.core.templatetags.extra_filters import markdown2html
+from tcms.issuetracker.base import IntegrationThread, IssueTrackerType
+
+
+class MantisAPI:
+    """
+    Mantis Rest API interaction class.
+
+    :meta private:
+    """
+
+    def __init__(self, base_url=None, password=None):
+        self.headers = {
+            "Accept": "application/json-patch+json",
+            "Content-type": "application/json-patch+json",
+            "Authorization": password,
+        }
+        self.base_url = base_url + "/api/rest"
+
+    def get_projects(self):
+        url = f"{self.base_url}/projects"
+        return self._request("GET", url, headers=self.headers)
+
+    def get_issue(self, issue_id):
+        url = f"{self.base_url}/issues/{issue_id}"
+        return self._request("GET", url, headers=self.headers)
+
+    def create_issue(self, body):
+        url = f"{self.base_url}/issues/"
+        return self._request("POST", url, headers=self.headers, json=body)
+
+    def update_issue(self, issue_id, body):
+        url = f"{self.base_url}/issues/{issue_id}"
+        return self._request("PATCH", url, headers=self.headers, json=body)
+
+    def get_comments(self, issue_id):
+        url = f"{self.base_url}/issues/{issue_id}"
+        return self._request("GET", url, headers=self.headers)["issues"][0]["notes"]
+
+    def add_comment(self, issue_id, body):
+        url = f"{self.base_url}/issues/{issue_id}/notes"
+        return self._request("POST", url, headers=self.headers, json=body)
+
+    def delete_comment(self, issue_id, note_id):
+        headers = {"Content-type": "application/json"}
+        url = f"{self.base_url}/issues/{issue_id}/notes/{note_id}"
+        return requests.request("DELETE", url, headers=headers, timeout=30)
+
+    @staticmethod
+    def _request(method, url, **kwargs):
+        return requests.request(method, url, timeout=30, **kwargs).json()
+
+
+class MantisThread(IntegrationThread):
+    """
+    Execute Mantis code in a thread!
+
+    Executed from the IssueTracker interface methods.
+
+    :meta private:
+    """
+
+    def post_comment(self):
+        comment_body = {
+            "text": markdown2html(self.text()),
+        }
+        self.rpc.add_comment(self.bug_id, comment_body)
+
+
+class Mantis(IssueTrackerType):
+    """
+    Support for Mantis. Requires:
+
+    :base_url: URL to Mantis Server - e.g. https://mantisbt.org
+    :api_password: Mantis API token
+
+    .. note::
+        You can leave the ``api_username`` field blank since
+        those are not used by issue tracker!
+    """
+
+    it_class = MantisThread
+
+    def _rpc_connection(self):
+        return MantisAPI(self.bug_system.base_url, self.bug_system.api_password)
+
+    def is_adding_testcase_to_issue_disabled(self):
+        return not (self.bug_system.base_url and self.bug_system.api_password)
+
+    def get_project_from_mantis(self, execution):
+        """
+        Returns the project from the actual Mantis instance.
+        Will try to match execution.run.plan.product.name, otherwise will
+        return the first found!
+
+        You may override this method if you want more control and customization,
+        see https://kiwitcms.org/blog/tags/customization/
+
+        .. versionadded:: 11.4
+        """
+        projects = self.rpc.get_projects()["projects"]
+        try:
+            project = next(
+                project
+                for project in projects
+                if project["name"] == execution.run.plan.product.name
+            )
+            return project["name"]
+        except StopIteration:
+            return projects[0]["name"]
+
+    def _report_issue(self, execution, user):
+        """
+        Mantis creates the Issue with Title
+        """
+
+        create_body = {
+            "summary": f"Failed test: {execution.case.summary}",
+            "description": markdown2html(self._report_comment(execution, user)),
+            "category": {"name": "General"},
+        }
+
+        try:
+            project_name = self.get_project_from_mantis(execution)
+            create_body["project"] = {"name": project_name}
+
+            issue = self.rpc.create_issue(create_body)["issue"]
+
+            issue_url = f"{self.bug_system.base_url}/view.php?id={issue['id']}"
+            # add a link reference that will be shown in the UI
+            LinkReference.objects.get_or_create(
+                execution=execution,
+                url=issue_url,
+                is_defect=True,
+            )
+
+            return (issue, issue_url)
+        except Exception:  # pylint: disable=broad-except
+            # something above didn't work so return a link for manually
+            # entering issue details with info pre-filled
+            url = self.bug_system.base_url
+            if not url.endswith("/"):
+                url += "/"
+
+            return (None, f"{url}bug_report_page.php")
+
+    def details(self, url):
+        """
+        Return issue details from Mantis
+        """
+        issue = self.rpc.get_issue(self.bug_id_from_url(url))
+        return {
+            "title": issue["issues"][0]["summary"],
+            "description": issue["issues"][0]["description"],
+        }

--- a/trackers_integration/tests/test_mantis.py
+++ b/trackers_integration/tests/test_mantis.py
@@ -1,0 +1,193 @@
+# pylint: disable=attribute-defined-outside-init
+import os
+import unittest
+
+from django.utils import timezone
+
+from tcms.core.contrib.linkreference.models import LinkReference
+from tcms.issuetracker.mantis import Mantis, MantisAPI
+from tcms.rpc.tests.utils import APITestCase
+from tcms.testcases.models import BugSystem
+from tcms.tests.factories import ComponentFactory, TestExecutionFactory
+
+
+class TestMantisIntegration(APITestCase):
+    existing_bug_id = 1
+    existing_bug_url = "http://localhost/rest/api/issues/1"
+    mantis_project = "Sample_Project"
+
+    def _fixture_setup(self):
+        super()._fixture_setup()
+
+        self.execution_1 = TestExecutionFactory()
+        self.execution_1.case.summary = "Tested at " + timezone.now().isoformat()
+        self.execution_1.case.text = "Given-When-Then"
+        self.execution_1.case.save()  # will generate history object
+        self.execution_1.run.summary = (
+            "Automated TR for Mantis integration on " + timezone.now().isoformat()
+        )
+        self.execution_1.run.save()
+
+        self.component = ComponentFactory(
+            name="Mantis integration", product=self.execution_1.run.plan.product
+        )
+        self.execution_1.case.add_component(self.component)
+
+        bug_system = BugSystem.objects.create(  # nosec:B106:hardcoded_password_funcarg
+            name="Mantis for kiwitcms/test-mantis-integration",
+            tracker_type="tcms.issuetracker.mantis.Mantis",
+            base_url="http://localhost",
+            api_url=self.mantis_project,
+            api_password=os.getenv("MANTIS_INTEGRATION_API_PASSWORD"),
+        )
+        self.integration = Mantis(bug_system, None)
+
+    def test_bug_id_from_url(self):
+        result = self.integration.bug_id_from_url(self.existing_bug_url)
+        self.assertEqual(self.existing_bug_id, result)
+
+    def test_details(self):
+        result = self.integration.details(self.existing_bug_url)
+
+        self.assertEqual("Hello World", result["title"])
+        self.assertIn("First public bug here", result["description"])
+
+    def test_auto_update_bugtracker(self):
+        initial_comments = self.integration.rpc.get_comments(self.existing_bug_id)
+
+        # simulate user adding a new bug URL to a TE and clicking
+        # 'Automatically update bug tracker'
+        result = self.rpc_client.TestExecution.add_link(
+            {
+                "execution_id": self.execution_1.pk,
+                "is_defect": True,
+                "url": self.existing_bug_url,
+            },
+            True,
+        )
+
+        # making sure RPC above returned the same URL
+        self.assertEqual(self.existing_bug_url, result["url"])
+
+        # wait until comments have been refreshed b/c this seem to happen async
+        initial_comments_length = len(initial_comments)
+        current_comments_length = initial_comments_length
+        while current_comments_length != initial_comments_length + 1:
+            comments = self.integration.rpc.get_comments(self.existing_bug_id)
+            current_comments_length = len(comments)
+
+        last_comment = comments[-1]
+
+        # assert that a comment has been added as the last one
+        # and also verify its text
+        for expected_string in [
+            "Confirmed via test execution",
+            f"TR-{self.execution_1.run_id}: {self.execution_1.run.summary}",
+            self.execution_1.run.get_full_url(),
+            f"TE-{self.execution_1.pk}: {self.execution_1.case.summary}",
+        ]:
+            self.assertIn(expected_string, last_comment["text"])
+
+        self.integration.rpc.delete_comment(self.existing_bug_id, last_comment["id"])
+
+    def test_report_issue_from_test_execution_1click_works(self):
+        # simulate user clicking the 'Report bug' button in TE widget, TR page
+        result = self.rpc_client.Bug.report(
+            self.execution_1.pk, self.integration.bug_system.pk
+        )
+        self.assertEqual(result["rc"], 0)
+        self.assertIn(self.integration.bug_system.base_url, result["response"])
+        self.assertIn("view.php?id=", result["response"])
+
+        new_issue_id = self.integration.bug_id_from_url(result["response"])
+        issue = self.integration.rpc.get_issue(new_issue_id)["issues"][0]
+
+        self.assertEqual(
+            f"Failed test: {self.execution_1.case.summary}", issue["summary"]
+        )
+        for expected_string in [
+            f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
+            self.execution_1.run.plan.product.name,
+            self.component.name,
+            "Steps to reproduce",
+            self.execution_1.case.text,
+        ]:
+            self.assertIn(expected_string, issue["description"])
+
+        # verify that LR has been added to TE
+        self.assertTrue(
+            LinkReference.objects.filter(
+                execution=self.execution_1,
+                url=result["response"],
+                is_defect=True,
+            ).exists()
+        )
+
+        # Close issue after test is finised.
+        close_issue(self.integration.rpc, new_issue_id)
+
+    def test_report_issue_from_test_execution_empty_baseurl_exception(self):
+        # simulate user clicking the 'Report bug' button in TE widget, TR page
+        bug_system = BugSystem.objects.create(  # nosec:B106:hardcoded_password_funcarg
+            name="Mantis for kiwitcms/test-mantis-integration Exception",
+            tracker_type="tcms.issuetracker.mantis.Mantis",
+            base_url="incorrect_url",
+            api_password=os.getenv("MANTIS_INTEGRATION_API_PASSWORD"),
+        )
+        integration = Mantis(bug_system, None)
+        result = self.rpc_client.Bug.report(
+            self.execution_1.pk, integration.bug_system.pk
+        )
+        self.assertIn("bug_report_page.php", result["response"])
+
+
+class TestMantisAPI(unittest.TestCase):
+    mantis_project = "Sample_Project"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        client_secret = os.getenv("MANTIS_INTEGRATION_API_PASSWORD")
+        base_url = "http://localhost"
+        cls.api_instance = MantisAPI(base_url, client_secret)
+
+        test_issue_data = {
+            "summary": "Sample Issue",
+            "description": "Sample Issue Description",
+            "category": {"name": "General"},
+            "project": {"name": cls.mantis_project},
+        }
+
+        result = cls.api_instance.create_issue(test_issue_data)
+        cls.issue_id = result["issue"]["id"]
+
+    @classmethod
+    def tearDownClass(cls):
+        close_issue(cls.api_instance, cls.issue_id)
+        return super().tearDownClass()
+
+    def test_create_issue(self):
+        test_issue_data = {
+            "summary": "Sample Issue",
+            "description": "Sample Issue Description",
+            "category": {"name": "General"},
+            "project": {"name": self.mantis_project},
+        }
+
+        result = self.api_instance.create_issue(test_issue_data)
+        self.assertEqual(result["issue"]["summary"], "Sample Issue")
+
+        # Close work item after test is finished.
+        close_issue(self.api_instance, result["issue"]["id"])
+
+    def test_add_comment(self):
+        test_comment_body = {"text": "Test Comment"}
+        result = self.api_instance.add_comment(self.issue_id, test_comment_body)
+        self.assertEqual(result["note"]["text"], "Test Comment")
+        self.api_instance.delete_comment(self.issue_id, result["note"]["id"])
+
+
+def close_issue(instance, issue_id):
+    close_issue_body = {"status": {"name": "closed"}}
+    instance.update_issue(issue_id, close_issue_body)


### PR DESCRIPTION
Opened with reference to the PR [2922](https://github.com/kiwitcms/Kiwi/pull/2922) on Kiwi repo.

Notes from the main PR:
```
Highlights

- Work In Progress
- Tests rely on MantisBT installed on localhost.
- MantisBT needs project name which is provided as "api_url" on Bug Tracker page of Kiwi TCMS
```
