### PR TITLE
Reorganize how settings are automatically configured

### DIFF
--- a/tcms_settings_dir/trackers_integration.py
+++ b/tcms_settings_dir/trackers_integration.py
@@ -3,18 +3,9 @@
 # Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
 # pylint: disable=undefined-variable
 
-if (
-    "trackers_integration.issuetracker.OpenProject"
-    not in EXTERNAL_BUG_TRACKERS  # noqa: F821
+for module_name in (
+    "trackers_integration.issuetracker.OpenProject",
+    "trackers_integration.issuetracker.Mantis",
 ):
-    EXTERNAL_BUG_TRACKERS.append(  # noqa: F821
-        "trackers_integration.issuetracker.OpenProject"
-    )
-
-if (
-    "trackers_integration.issuetracker.Mantis"
-    not in EXTERNAL_BUG_TRACKERS  # noqa: F821
-):
-    EXTERNAL_BUG_TRACKERS.append(  # noqa: F821
-        "trackers_integration.issuetracker.Mantis"
-    )
+    if module_name not in EXTERNAL_BUG_TRACKERS:  # noqa: F821
+        EXTERNAL_BUG_TRACKERS.append(module_name)  # noqa: F821


### PR DESCRIPTION
to avoid excessively typing module names multiple times