### PR TITLE
Show assignee instead of broken description

### DIFF
--- a/trackers_integration/issuetracker/openproject.py
+++ b/trackers_integration/issuetracker/openproject.py
@@ -234,7 +234,12 @@ class OpenProject(base.IssueTrackerType):
         issue = self.rpc.get_workpackage(self.bug_id_from_url(url))
         issue_type = issue["_embedded"]["type"]["name"].upper()
         status = issue["_embedded"]["status"]["name"].upper()
+        try:
+            assignee = issue["_embedded"]["assignee"]["name"]
+        except Exception as err:
+            assignee = "unassigned"
+
         return {
             "title": f"{status} {issue_type}: " + issue["subject"],
-            "description": issue["description"]["html"],
+            "description": "Assignee: " + assignee,
         }

--- a/trackers_integration/issuetracker/openproject.py
+++ b/trackers_integration/issuetracker/openproject.py
@@ -78,6 +78,7 @@ class API:
         url = f"{self.base_url}/projects/{project_id}/categories"
         return self._request("GET", url, auth=self.auth)
 
+
 class OpenProject(base.IssueTrackerType):
     """
     .. versionadded:: 11.6-Enterprise
@@ -182,7 +183,9 @@ class OpenProject(base.IssueTrackerType):
             project_id, getattr(settings, "OPENPROJECT_WORKPACKAGE_TYPE_NAME", "Bug")
         )
 
-        category = self.get_workpackage_category(project_id, execution.case.category.name)
+        category = self.get_workpackage_category(
+            project_id, execution.case.category.name
+        )
 
         if category:
             new_issue = self.rpc.create_workpackage(

--- a/trackers_integration/issuetracker/openproject.py
+++ b/trackers_integration/issuetracker/openproject.py
@@ -74,6 +74,9 @@ class API:
         url = f"{self.base_url}/projects/{project_id}/types"
         return self._request("GET", url, auth=self.auth)
 
+    def get_workpackage_categories(self, project_id):
+        url = f"{self.base_url}/projects/{project_id}/categories"
+        return self._request("GET", url, auth=self.auth)
 
 class OpenProject(base.IssueTrackerType):
     """
@@ -155,6 +158,21 @@ class OpenProject(base.IssueTrackerType):
         except Exception as err:
             raise RuntimeError("WorkPackage Type not found") from err
 
+    def get_workpackage_category(self, project_id, name):
+        """
+        Return a WorkPackage category matching by name.
+        If there is no match then return None.
+        """
+        try:
+            categories = self.rpc.get_workpackage_categories(project_id)
+            for category in categories["_embedded"]["elements"]:
+                if category["name"].lower() == name.lower():
+                    return category
+
+            return None
+        except Exception as err:
+            raise RuntimeError("WorkPackage Category not found") from err
+
     def _report_issue(self, execution, user):
         project = self.get_project_by_name(execution.run.plan.product.name)
         project_id = project["id"]
@@ -164,16 +182,31 @@ class OpenProject(base.IssueTrackerType):
             project_id, getattr(settings, "OPENPROJECT_WORKPACKAGE_TYPE_NAME", "Bug")
         )
 
-        new_issue = self.rpc.create_workpackage(
-            project_id,
-            {
-                "subject": f"Failed test: {execution.case.summary}",
-                "description": {"raw": self._report_comment(execution, user)},
-                "_links": {
-                    "type": _type["_links"]["self"],
+        category = self.get_workpackage_category(project_id, execution.case.category.name)
+
+        if category:
+            new_issue = self.rpc.create_workpackage(
+                project_id,
+                {
+                    "subject": f"Failed test: {execution.case.summary}",
+                    "description": {"raw": self._report_comment(execution, user)},
+                    "_links": {
+                        "type": _type["_links"]["self"],
+                        "category": category["_links"]["self"],
+                    },
                 },
-            },
-        )
+            )
+        else:
+            new_issue = self.rpc.create_workpackage(
+                project_id,
+                {
+                    "subject": f"Failed test: {execution.case.summary}",
+                    "description": {"raw": self._report_comment(execution, user)},
+                    "_links": {
+                        "type": _type["_links"]["self"],
+                    },
+                },
+            )
 
         _id = new_issue["id"]
         new_url = f"{self.bug_system.base_url}/projects/{project_identifier}/work_packages/{_id}"


### PR DESCRIPTION
Right now the OpenProject integration shows a broken HTML rendering of the description of the work package. It is possible to fix this by setting the rendering to raw, but in that case there won't be any line breaks in the description.

For long descriptions it can happen, that the box is too big and fills the whole page. Therefore a more meaningful information like the assignee of the bug could be shown. As not every issue has an assignee I have also added a check to enter unassigned in case no assignee is assigned.

This resolves issue #38 

An example of the new rendering:
![image](https://github.com/kiwitcms/trackers-integration/assets/2744377/91dd18aa-4771-45d8-a8fd-262a2770b891)
