### PR TITLE
Remove btree_gin extension from CI b/c not needed

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,6 @@ jobs:
 
     - name: Initialize bugs DB
       run: |
-        docker exec -i postgresql_database psql -c "CREATE EXTENSION IF NOT EXISTS btree_gin;"
         docker exec -i postgresql_database psql -c "ALTER USER kiwi CREATEDB;"
 
         ./tests/${{ matrix.tracker }}/initialize-data


### PR DESCRIPTION
this was copied over from kiwitcms-github-marketplace plugin and is used when having a GinIndex on a JSON field which we don't have here!