### PR TITLE
Use Django's cache for private API tokens

### DIFF
--- a/trackers_integration/auth.py
+++ b/trackers_integration/auth.py
@@ -1,3 +1,5 @@
+from django.core.cache import cache
+
 from trackers_integration.models import ApiToken
 
 
@@ -6,9 +8,12 @@ def personal_api_token(issue_tracker):
     if not issue_tracker.request:
         return None
 
-    token = ApiToken.objects.filter(
-        owner=issue_tracker.request.user, base_url=issue_tracker.bug_system.base_url
-    ).first()
+    token = cache.get(
+        f"api-token-of-{issue_tracker.request.user.pk}-for-{issue_tracker.bug_system.pk}",
+        ApiToken.objects.filter(
+            owner=issue_tracker.request.user, base_url=issue_tracker.bug_system.base_url
+        ).first()
+    )
     if token:
         return (token.api_username, token.api_password)
 

--- a/trackers_integration/auth.py
+++ b/trackers_integration/auth.py
@@ -12,7 +12,7 @@ def personal_api_token(issue_tracker):
         f"api-token-of-{issue_tracker.request.user.pk}-for-{issue_tracker.bug_system.pk}",
         ApiToken.objects.filter(
             owner=issue_tracker.request.user, base_url=issue_tracker.bug_system.base_url
-        ).first()
+        ).first(),
     )
     if token:
         return (token.api_username, token.api_password)


### PR DESCRIPTION
to minimize the number of DB queries