### PR TITLE
Build & test with Python 3.12 and Django 6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,12 @@ various Issue Trackers.
 Changelog
 ---------
 
+v1.4.0 (16 Jun 2026)
+~~~~~~~~~~~~~~~~~~~~
+
+- Minimum supported Python version is 3.12
+
+
 v1.3.1 (03 Jun 2026)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     url="https://github.com/kiwitcms/trackers-integration/",
     license="AGPLv3+",
     install_requires=get_install_requires("requirements.txt"),
+    python_requires=">=3.12",
     include_package_data=True,
     packages=find_packages(exclude=["test_project*", "*.tests"]),
     zip_safe=False,
@@ -49,9 +50,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Framework :: Django :: 6.0",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires(path):
 
 setup(
     name="kiwitcms-trackers-integration",
-    version="1.3.1",
+    version="1.4.0",
     description="Integration between Kiwi TCMS and various Issue Trackers",
     long_description=get_long_description(),
     author="Kiwi TCMS",


### PR DESCRIPTION
Build & test against a minimum of Python 3.12 and Django 6 (latest kiwitcms/Kiwi from the master branch, which now pins Django 6.0).

- Declare `python_requires=">=3.12"`
- Add `Framework :: Django :: 6.0` classifier$\n- Drop obsolete Python 3.8/3.9/3.11 classifiers