### PR TITLE
Test all RPC requests against Kiwi PR #4451 (migrate-django-modern-rpc-v2)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+DEBUG
+
 Extra Issue Tracker integration for Kiwi TCMS
 =============================================
 


### PR DESCRIPTION
Clone Kiwi TCMS from the `migrate-django-modern-rpc-v2` branch and build an intermediary Docker image so the internals integration tests run against the new RPC decorator pattern.

This re-applies the same approach from kiwitcms/tcms-api#110 to the trackers-integration repo for verifying compatibility across bug tracker plugins.

- Commit 1 — DEBUG: modifies the Makefile's `checkout_kiwi` target to clone from `migrate-django-modern-rpc-v2`
- Commit 2 — builds `pub.kiwitcms.eu/kiwitcms/kiwi:latest` via `make docker-image` before the Dockerize step